### PR TITLE
Fix: Update Firestore database name to 'wps-database'

### DIFF
--- a/index.html
+++ b/index.html
@@ -298,7 +298,7 @@
         // Initialize Firebase
         const firebaseApp = initializeApp(firebaseConfig);
         const analytics = getAnalytics(firebaseApp);
-        const db = getFirestore(firebaseApp, 'user-data'); // Using named database 'user-data'
+        const db = getFirestore(firebaseApp, 'wps-database'); // Using named database 'wps-database'
         const auth = getAuth(firebaseApp);
         const googleProvider = new GoogleAuthProvider();
 


### PR DESCRIPTION
The Firebase client was attempting to connect to a Firestore database named 'user-data' as specified in the code. The user had created a named database called 'wps-database'.

This commit updates the `getFirestore` initialization in `index.html` to use the correct database name 'wps-database', resolving the issue where the application would get stuck on 'Loading user data...' after a successful Google Sign-In.