### PR TITLE
Feat: Allow super-admins to manage admin status of users

### DIFF
--- a/index.html
+++ b/index.html
@@ -354,7 +354,7 @@
         let firestoreUserRoles = {}; // Stores roles fetched from Firestore
         let firestoreActivityLogs = []; // Stores logs fetched from Firestore
 
-        const ROLES = ['Member', 'Moderator', 'Banned']; // Defined roles for the system
+        const ROLES = ['Member', 'Moderator', 'Admin', 'Banned']; // Defined roles for the system
 
         // Firestore Collection References (implicitly pointing to 'user-data' database)
         const userRolesCollectionRef = collection(db, `artifacts/${appId}/public/data/user_roles`);


### PR DESCRIPTION
- Added 'Admin' to the list of assignable roles.
- Super-admins and users assigned the 'Admin' role can now access the admin panel and manage other users' roles.
- This allows for delegation of administrative tasks within the application.