### PR TITLE
fix: Resolve login issue by removing access to non-existent button

### DIFF
--- a/index.html
+++ b/index.html
@@ -1358,7 +1358,7 @@
                         }
                     }
                     googleLoginButton.disabled = false;
-                    emailPasswordLoginButton.disabled = false;
+                    // emailPasswordLoginButton.disabled = false; // This line is removed as the element no longer exists
 
                 } else {
                     // No Firebase user is currently authenticated


### PR DESCRIPTION
Re-applied the fix to remove a line of JavaScript that attempted to set the 'disabled' property on `emailPasswordLoginButton`. This button was previously removed from the HTML, and accessing it caused a TypeError during the `onAuthStateChanged` event after successful authentication, preventing the login process from completing correctly.