### PR TITLE
Fix: Ensure chip_count is correctly initialized and handled

### DIFF
--- a/index.html
+++ b/index.html
@@ -981,12 +981,17 @@
                     userData.chip_count = 0; // Initialize chip_count for new users
                     console.log("New user profile created with initial chip_count: 0 for user:", user.uid);
                 } else {
-                    // If user exists, chip_count is managed elsewhere (e.g., admin panel)
-                    // We can ensure it exists if it somehow got deleted, but default to not overwriting it.
                     const existingData = userProfileSnap.data();
-                    if (typeof existingData.chip_count === 'undefined') {
-                        userData.chip_count = 0; // Add if missing, though ideally it shouldn't be.
-                         console.log("Existing user profile was missing chip_count. Initialized to 0 for user:", user.uid);
+                    // Ensure chip_count is a number, defaulting to 0 if it's missing or not a number.
+                    if (typeof existingData.chip_count === 'number') {
+                        userData.chip_count = existingData.chip_count;
+                    } else {
+                        userData.chip_count = 0; // Default to 0 if not a number or undefined
+                        if (typeof existingData.chip_count !== 'undefined') {
+                            console.log(`Existing user profile had a non-numeric chip_count ('${existingData.chip_count}'). Corrected to 0 for user:`, user.uid);
+                        } else {
+                            console.log("Existing user profile was missing chip_count. Initialized to 0 for user:", user.uid);
+                        }
                     }
                 }
 


### PR DESCRIPTION
- Modified `handleLoginSuccess` in `index.html` to ensure that `chip_count` for a user profile is always a number.
- If a new user is created, `chip_count` defaults to 0.
- If an existing user's profile is loaded:
    - If `chip_count` is missing, it's set to 0.
    - If `chip_count` is present but not a number (e.g., null, string), it's corrected to 0.
    - If `chip_count` is already a valid number, it's preserved. This change aims to resolve issues where the application might get stuck during user data loading due to missing or invalid `chip_count` values in Firestore.