### PR TITLE
Fix: Correct Firestore import for getDoc and handle chip_count

### DIFF
--- a/index.html
+++ b/index.html
@@ -305,7 +305,7 @@
         import { initializeApp } from "https://www.gstatic.com/firebasejs/11.9.1/firebase-app.js";
         import { getAnalytics } from "https://www.gstatic.com/firebasejs/11.9.1/firebase-analytics.js";
         import { getAuth, signInWithCustomToken, onAuthStateChanged, GoogleAuthProvider, signInWithPopup, linkWithPopup, signOut } from "https://www.gstatic.com/firebasejs/11.9.1/firebase-auth.js";
-        import { getFirestore, doc, setDoc, addDoc, onSnapshot, collection, query, getDocs, deleteDoc } from "https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js";
+        import { getFirestore, doc, getDoc, setDoc, addDoc, onSnapshot, collection, query, getDocs, deleteDoc } from "https://www.gstatic.com/firebasejs/11.9.1/firebase-firestore.js";
 
         // --- Firebase Configuration ---
         const firebaseConfig = {


### PR DESCRIPTION
- Added `getDoc` to the Firestore import statement in `index.html` to resolve `ReferenceError: getDoc is not defined`.
- Modified `handleLoginSuccess` to ensure `chip_count` is correctly initialized/handled:
    - New users default to `chip_count: 0`.
    - Existing users with missing `chip_count` get it set to 0.
    - Existing users with non-numeric `chip_count` (e.g., null, string) have it corrected to 0.
    - Valid numeric `chip_count` values are preserved. This addresses issues related to application loading due to invalid `chip_count` data and fixes the previous runtime error.