### PR TITLE
feat: Implement investment action button logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -1025,6 +1025,326 @@
             }
         }
 
+        async function editPendingOffer(investmentId) {
+            if (!auth.currentUser) {
+                showMessage("You must be logged in to edit an offer.", "error");
+                return;
+            }
+            const currentUid = auth.currentUser.uid;
+            const investment = firestoreInvestments.find(inv => inv.id === investmentId);
+
+            if (!investment) {
+                showMessage("Investment offer not found.", "error");
+                return;
+            }
+
+            if (investment.investorUid !== currentUid) {
+                showMessage("You are not authorized to edit this offer.", "error");
+                return;
+            }
+
+            if (investment.status !== 'pending_investee_action') {
+                showMessage("This offer can only be edited if it's pending investee action.", "info");
+                return;
+            }
+
+            // Simplification: Disallow editing if there's any amendment history/messages
+            if (investment.investeeMessage || investment.investorMessage) {
+                showMessage("This offer cannot be edited as it has amendment messages. Please cancel and create a new offer if you wish to change terms.", "info");
+                return;
+            }
+
+            const newOfferAmountStr = prompt("Enter new offer amount:", investment.offerAmount);
+            if (newOfferAmountStr === null) return; // User cancelled
+            const newOfferAmount = parseInt(newOfferAmountStr, 10);
+
+            const newPayoutPercentStr = prompt("Enter new requested payout percentage (1-100%):", investment.requestedPayoutPercent);
+            if (newPayoutPercentStr === null) return;
+            const newPayoutPercent = parseInt(newPayoutPercentStr, 10);
+
+            const newHandsPayoutStr = prompt("Enter new hands until payout:", investment.handsForPayout);
+            if (newHandsPayoutStr === null) return;
+            const newHandsPayout = parseInt(newHandsPayoutStr, 10);
+
+            // Validation for new values
+            const investorProfile = allFirebaseUsersData.find(p => p.uid === currentUid);
+            const investorChips = investorProfile ? (investorProfile.chip_count || 0) : 0;
+
+            if (isNaN(newOfferAmount) || newOfferAmount <= 0) {
+                showMessage("Invalid new offer amount.", "error");
+                return;
+            }
+            if (newOfferAmount > investorChips) {
+                showMessage("You do not have enough chips for this new offer amount.", "error");
+                return;
+            }
+            if (isNaN(newPayoutPercent) || newPayoutPercent <= 0 || newPayoutPercent > 100) {
+                showMessage("Invalid new payout percentage (must be 1-100).", "error");
+                return;
+            }
+            if (isNaN(newHandsPayout) || newHandsPayout <= 0) {
+                showMessage("Invalid new number of hands for payout.", "error");
+                return;
+            }
+
+            showMessage("Updating investment offer...", "info");
+            const investmentDocRef = doc(investmentsCollectionRef, investmentId);
+            try {
+                await updateDoc(investmentDocRef, {
+                    offerAmount: newOfferAmount,
+                    requestedPayoutPercent: newPayoutPercent,
+                    handsForPayout: newHandsPayout,
+                    handsRemaining: newHandsPayout, // Reset handsRemaining as well
+                    lastUpdated: serverTimestamp()
+                    // Status remains 'pending_investee_action'
+                });
+                showMessage("Investment offer updated successfully. Investee will see the new terms.", "success");
+                // UI will update via Firestore listener.
+            } catch (error) {
+                console.error("Error updating investment offer:", error);
+                showMessage(`Failed to update offer: ${error.message}`, "error");
+            }
+        }
+
+        async function handleInvestorAcceptAmendment(investmentId) {
+            if (!auth.currentUser) {
+                showMessage("You must be logged in to respond to an amendment.", "error");
+                return;
+            }
+            const currentUid = auth.currentUser.uid;
+            const investment = firestoreInvestments.find(inv => inv.id === investmentId);
+
+            if (!investment) {
+                showMessage("Investment offer not found.", "error");
+                return;
+            }
+            if (investment.investorUid !== currentUid) {
+                showMessage("You are not authorized to respond to this amendment.", "error");
+                return;
+            }
+            if (investment.status !== 'pending_investor_action') {
+                showMessage("This offer is not awaiting your response to an amendment.", "info");
+                return;
+            }
+
+            showMessage("Accepting amended investment offer...", "info");
+
+            const investorProfileRef = doc(userProfilesCollectionRef, currentUid); // currentUid is investorUid
+            const investeeProfileRef = doc(userProfilesCollectionRef, investment.investeeUid);
+            const investmentDocRef = doc(investmentsCollectionRef, investmentId);
+
+            try {
+                const investorSnap = await getDoc(investorProfileRef);
+                const investeeSnap = await getDoc(investeeProfileRef);
+
+                if (!investorSnap.exists() || !investeeSnap.exists()) {
+                    showMessage("Investor or Investee profile not found. Cannot complete acceptance.", "error");
+                    await updateDoc(investmentDocRef, { status: 'error_profile_missing_on_amend_accept', lastUpdated: serverTimestamp() });
+                    return;
+                }
+
+                const investorData = investorSnap.data();
+                const investeeData = investeeSnap.data();
+                const investorCurrentChips = investorData.chip_count || 0;
+                const offerAmount = investment.offerAmount;
+
+                if (investorCurrentChips < offerAmount) {
+                    showMessage("You do not have sufficient chips to fund this investment. The offer is now void.", "error");
+                    await updateDoc(investmentDocRef, { status: 'cancelled_insufficient_funds', lastUpdated: serverTimestamp() });
+                    return;
+                }
+
+                const batch = writeBatch(db);
+                batch.update(investorProfileRef, { chip_count: investorCurrentChips - offerAmount });
+                batch.update(investeeProfileRef, { chip_count: (investeeData.chip_count || 0) + offerAmount });
+                batch.update(investmentDocRef, {
+                    status: 'active',
+                    acceptedDate: serverTimestamp(), // Terms were implicitly accepted with amendment
+                    handsRemaining: investment.handsForPayout,
+                    lastUpdated: serverTimestamp()
+                });
+
+                await batch.commit();
+                showMessage("Amendment accepted and investment is now active! Chips transferred.", "success");
+
+            } catch (error) {
+                console.error("Error accepting amendment:", error);
+                showMessage(`Failed to accept amendment: ${error.message}`, "error");
+            }
+        }
+
+        async function handleInvestorRejectAmendment(investmentId) {
+            if (!auth.currentUser) {
+                showMessage("You must be logged in to respond to an amendment.", "error");
+                return;
+            }
+            const currentUid = auth.currentUser.uid;
+            const investment = firestoreInvestments.find(inv => inv.id === investmentId);
+
+            if (!investment) {
+                showMessage("Investment offer not found.", "error");
+                return;
+            }
+            if (investment.investorUid !== currentUid) {
+                showMessage("You are not authorized to respond to this amendment.", "error");
+                return;
+            }
+            if (investment.status !== 'pending_investor_action') {
+                showMessage("This offer is not awaiting your response to an amendment.", "info");
+                return;
+            }
+
+            if (!confirm("Are you sure you want to reject this amendment and effectively cancel the offer?")) {
+                return;
+            }
+
+            showMessage("Rejecting amendment...", "info");
+            const investmentDocRef = doc(investmentsCollectionRef, investmentId);
+            try {
+                await updateDoc(investmentDocRef, {
+                    status: 'declined_by_investor', // Or 'amendment_rejected_by_investor'
+                    lastUpdated: serverTimestamp()
+                });
+                showMessage("Amendment rejected. The investment offer is now closed.", "success");
+            } catch (error) {
+                console.error("Error rejecting amendment:", error);
+                showMessage(`Failed to reject amendment: ${error.message}`, "error");
+            }
+        }
+
+        async function amendInvestment(investmentId) {
+            if (!auth.currentUser) {
+                showMessage("You must be logged in to amend an investment.", "error");
+                return;
+            }
+            const currentUid = auth.currentUser.uid;
+            const investment = firestoreInvestments.find(inv => inv.id === investmentId);
+
+            if (!investment) {
+                showMessage("Investment offer not found.", "error");
+                return;
+            }
+
+            if (investment.investeeUid !== currentUid) {
+                showMessage("You are not authorized to amend this investment.", "error");
+                return;
+            }
+
+            if (investment.status !== 'pending_investee_action') {
+                showMessage(`This investment cannot be amended at this time (Status: ${investment.status}).`, "info");
+                return;
+            }
+
+            const amendmentMessage = prompt("Enter your amendment message to the investor (e.g., suggest different terms):");
+
+            if (amendmentMessage === null) { // User cancelled the prompt
+                return; // Do nothing if prompt is cancelled
+            }
+
+            if (!amendmentMessage.trim()) {
+                showMessage("Amendment message cannot be empty if you choose to submit.", "error");
+                return;
+            }
+
+            showMessage("Submitting your amendment...", "info");
+            const investmentDocRef = doc(investmentsCollectionRef, investmentId);
+
+            try {
+                await updateDoc(investmentDocRef, {
+                    status: 'pending_investor_action', // Now investor needs to respond
+                    investeeMessage: amendmentMessage,
+                    lastUpdated: serverTimestamp()
+                });
+                showMessage("Amendment submitted. Waiting for investor response.", "success");
+                // UI will update via Firestore listener, which calls renderIncomingOffersList.
+            } catch (error) {
+                console.error("Error submitting amendment:", error);
+                showMessage(`Failed to submit amendment: ${error.message}`, "error");
+            }
+        }
+
+        async function cancelPendingOffer(investmentId) {
+            if (!auth.currentUser) {
+                showMessage("You must be logged in to cancel an offer.", "error");
+                return;
+            }
+            const currentUid = auth.currentUser.uid;
+            const investment = firestoreInvestments.find(inv => inv.id === investmentId);
+
+            if (!investment) {
+                showMessage("Investment offer not found.", "error");
+                return;
+            }
+
+            if (investment.investorUid !== currentUid) {
+                showMessage("You are not authorized to cancel this offer.", "error");
+                return;
+            }
+
+            if (investment.status !== 'pending_investee_action' && investment.status !== 'pending_investor_action') {
+                showMessage(`This offer cannot be cancelled (Status: ${investment.status}). It must be pending action.`, "info");
+                return;
+            }
+
+            if (!confirm("Are you sure you want to cancel this investment offer?")) {
+                return;
+            }
+
+            showMessage("Cancelling investment offer...", "info");
+            const investmentDocRef = doc(investmentsCollectionRef, investmentId);
+
+            try {
+                await updateDoc(investmentDocRef, {
+                    status: 'cancelled_by_investor',
+                    lastUpdated: serverTimestamp()
+                });
+                showMessage("Investment offer cancelled.", "success");
+                // UI will update via Firestore listener.
+            } catch (error) {
+                console.error("Error cancelling investment offer:", error);
+                showMessage(`Failed to cancel offer: ${error.message}`, "error");
+            }
+        }
+
+        async function declineInvestment(investmentId) {
+            if (!auth.currentUser) {
+                showMessage("You must be logged in to decline an investment.", "error");
+                return;
+            }
+            const currentUid = auth.currentUser.uid;
+            const investment = firestoreInvestments.find(inv => inv.id === investmentId);
+
+            if (!investment) {
+                showMessage("Investment offer not found.", "error");
+                return;
+            }
+
+            if (investment.investeeUid !== currentUid) {
+                showMessage("You are not authorized to decline this investment.", "error");
+                return;
+            }
+
+            if (investment.status !== 'pending_investee_action') {
+                showMessage(`This investment is no longer pending your action (Status: ${investment.status}).`, "info");
+                return;
+            }
+
+            showMessage("Declining investment offer...", "info");
+            const investmentDocRef = doc(investmentsCollectionRef, investmentId);
+
+            try {
+                await updateDoc(investmentDocRef, {
+                    status: 'declined_by_investee',
+                    lastUpdated: serverTimestamp()
+                });
+                showMessage("Investment offer declined.", "success");
+                // UI will update via Firestore listener.
+            } catch (error) {
+                console.error("Error declining investment:", error);
+                showMessage(`Failed to decline investment: ${error.message}`, "error");
+            }
+        }
+
         async function adminPlaceBetForPlayer(roomId, targetPlayerId, targetPlayerName, currentChips) {
             if (!auth.currentUser || !hasAdminAccess(auth.currentUser.uid)) {
                 showMessage("You do not have permission to place bets for players.", "error");
@@ -4129,16 +4449,22 @@
                     <p class="text-sm text-gray-600">Offered Date: <span class="font-medium">${formatDate(share.offerDate)}</span></p>
                     ${share.status === 'active' ? `<p class="text-sm text-gray-600">Hands Remaining: <span class="font-medium">${share.handsRemaining}</span></p>` : ''}
                     ${share.status === 'active' || share.status === 'completed' ? `<p class="text-sm text-gray-600">Return on Investment (ROI): <span class="font-medium">${roiText}</span></p>` : ''}
-                    ${share.investeeMessage && (share.status === 'pending_investor_action' || share.status === 'declined') ? `<div class="mt-2 p-2 bg-orange-100 border-l-4 border-orange-500 text-orange-700 text-xs"><p><strong>Investee Message:</strong> ${share.investeeMessage}</p></div>` : ''}
+                    ${share.investeeMessage && (share.status === 'pending_investor_action' || share.status === 'declined_by_investee' || statusText.toLowerCase().includes('rejected')) ? `<div class="mt-2 p-2 bg-orange-100 border-l-4 border-orange-500 text-orange-700 text-xs"><p><strong>Investee Message:</strong> ${share.investeeMessage}</p></div>` : ''}
+                    ${share.investorMessage && (share.status === 'pending_investee_action') ? `<div class="mt-2 p-2 bg-blue-100 border-l-4 border-blue-500 text-blue-700 text-xs"><p><strong>Your Last Message:</strong> ${share.investorMessage}</p></div>` : ''}
                     <div class="mt-2 space-x-2">
-                        ${(share.status === 'pending_investee_action' || share.status === 'pending_investor_action') ? `
+                        ${(share.status === 'pending_investee_action' && !share.investorMessage && !share.investeeMessage) ? `
                             <button data-id="${share.id}" class="edit-share-offer-btn text-xs bg-blue-500 hover:bg-blue-600 text-white py-1 px-2 rounded">Edit</button>
+                        ` : ''}
+                        ${(share.status === 'pending_investee_action' || share.status === 'pending_investor_action') ? `
                             <button data-id="${share.id}" class="cancel-share-offer-btn text-xs bg-red-500 hover:bg-red-600 text-white py-1 px-2 rounded">Cancel Offer</button>
                         ` : ''}
-                         ${(share.status === 'pending_investor_action' && share.investeeMessage) ? `
-                            <button data-id="${share.id}" class="view-investee-message-btn text-xs bg-gray-500 hover:bg-gray-600 text-white py-1 px-2 rounded">View Message</button>
+                        ${(share.status === 'pending_investor_action') ? `
+                            <button data-id="${share.id}" class="accept-amendment-btn text-xs bg-green-500 hover:bg-green-600 text-white font-bold py-1 px-3 rounded">Accept Amendment</button>
+                            <button data-id="${share.id}" class="reject-amendment-btn text-xs bg-red-500 hover:bg-red-700 text-white font-bold py-1 px-3 rounded">Reject Amendment & Cancel</button>
+                            <!-- Optionally, add a button here to propose a counter-amendment -->
+                            <button data-id="${share.id}" class="cancel-share-offer-btn text-xs bg-gray-500 hover:bg-gray-600 text-white py-1 px-2 rounded">Cancel Offer Entirely</button>
                         ` : ''}
-                         <!-- Add more buttons for other statuses if needed -->
+                         <!-- View Message button might be redundant if message is displayed above -->
                     </div>
                 `;
                 mySharesList.appendChild(itemDiv);
@@ -4266,14 +4592,139 @@
                 activateInvestmentsTab(sharesTab, sharesContent);
                 if (auth.currentUser) {
                     populateInvestmentPlayerSelect(); // For the offer form on Shares tab
+                    renderMySharesList(); // Re-render to ensure buttons are fresh if data changed
                 }
             });
         }
         if (offersTab) {
             offersTab.addEventListener('click', () => {
                 activateInvestmentsTab(offersTab, offersContent);
-                // Future: if Offers tab needs dynamic data on click, call its population function here
+                if (auth.currentUser) {
+                    renderIncomingOffersList(); // Re-render to ensure buttons are fresh
+                    renderMyInvestmentsAsInvesteeList();
+                }
             });
+        }
+
+        // Event Delegation for Investment Action Buttons
+        if (mySharesList) {
+            mySharesList.addEventListener('click', (event) => {
+                const target = event.target;
+                const investmentId = target.dataset.id;
+
+                if (!investmentId) return; // Click was not on a button with data-id
+
+                if (target.classList.contains('cancel-share-offer-btn')) {
+                    cancelPendingOffer(investmentId);
+                } else if (target.classList.contains('accept-amendment-btn')) {
+                    handleInvestorAcceptAmendment(investmentId);
+                } else if (target.classList.contains('reject-amendment-btn')) {
+                    handleInvestorRejectAmendment(investmentId);
+                } else if (target.classList.contains('edit-share-offer-btn')) {
+                    editPendingOffer(investmentId);
+                }
+            });
+        }
+
+        if (incomingOffersList) {
+            incomingOffersList.addEventListener('click', (event) => {
+                const target = event.target;
+                const investmentId = target.dataset.id;
+
+                if (!investmentId) return; // Click was not on a button with data-id
+
+                if (target.classList.contains('accept-investment-btn')) {
+                    acceptInvestment(investmentId);
+                } else if (target.classList.contains('decline-investment-btn')) {
+                    declineInvestment(investmentId);
+                } else if (target.classList.contains('amend-investment-btn')) { // Added this condition
+                    amendInvestment(investmentId);
+                }
+            });
+        }
+
+        async function acceptInvestment(investmentId) {
+            if (!auth.currentUser) {
+                showMessage("You must be logged in to accept an investment.", "error");
+                return;
+            }
+            const currentUid = auth.currentUser.uid;
+            const investment = firestoreInvestments.find(inv => inv.id === investmentId);
+
+            if (!investment) {
+                showMessage("Investment offer not found.", "error");
+                return;
+            }
+
+            if (investment.investeeUid !== currentUid) {
+                showMessage("You are not authorized to accept this investment.", "error");
+                return;
+            }
+
+            if (investment.status !== 'pending_investee_action') {
+                showMessage(`This investment is no longer pending your action (Status: ${investment.status}).`, "info");
+                return;
+            }
+
+            showMessage("Accepting investment offer...", "info");
+
+            const investorProfileRef = doc(userProfilesCollectionRef, investment.investorUid);
+            const investeeProfileRef = doc(userProfilesCollectionRef, currentUid); // currentUid is investeeUid
+            const investmentDocRef = doc(investmentsCollectionRef, investmentId);
+
+            try {
+                const investorSnap = await getDoc(investorProfileRef);
+                const investeeSnap = await getDoc(investeeProfileRef);
+
+                if (!investorSnap.exists()) {
+                    showMessage("Investor profile not found. Cannot complete acceptance.", "error");
+                    // Optionally, update investment status to an error state here
+                    await updateDoc(investmentDocRef, { status: 'error_investor_profile_missing', lastUpdated: serverTimestamp() });
+                    return;
+                }
+                if (!investeeSnap.exists()) {
+                    // Should not happen if current user is the investee and logged in
+                    showMessage("Your profile not found. Cannot complete acceptance.", "error");
+                    return;
+                }
+
+                const investorData = investorSnap.data();
+                const investeeData = investeeSnap.data();
+                const investorCurrentChips = investorData.chip_count || 0;
+                const offerAmount = investment.offerAmount;
+
+                if (investorCurrentChips < offerAmount) {
+                    showMessage("Investor does not have sufficient chips to fund this investment. The offer may be void.", "error");
+                    // Update investment status to reflect this issue
+                    await updateDoc(investmentDocRef, { status: 'cancelled_insufficient_funds', lastUpdated: serverTimestamp() });
+                    return;
+                }
+
+                const batch = writeBatch(db);
+
+                // 1. Decrement investor's chips
+                batch.update(investorProfileRef, { chip_count: investorCurrentChips - offerAmount });
+
+                // 2. Increment investee's chips
+                const investeeCurrentChips = investeeData.chip_count || 0;
+                batch.update(investeeProfileRef, { chip_count: investeeCurrentChips + offerAmount });
+
+                // 3. Update investment document
+                batch.update(investmentDocRef, {
+                    status: 'active',
+                    acceptedDate: serverTimestamp(),
+                    handsRemaining: investment.handsForPayout, // Initialize handsRemaining
+                    lastUpdated: serverTimestamp()
+                });
+
+                await batch.commit();
+                showMessage("Investment accepted successfully! Chips transferred.", "success");
+                // UI will update via Firestore listener automatically.
+
+            } catch (error) {
+                console.error("Error accepting investment:", error);
+                showMessage(`Failed to accept investment: ${error.message}`, "error");
+            }
         }
 
     </script>


### PR DESCRIPTION
Adds functionality for:
- Investees to accept, decline, or amend investment offers.
- Investors to cancel their pending offers.
- Investors to accept or reject amendments made by investees.
- Investors to edit the terms of their pending offers (if no prior amendments).

Updates UI rendering and event delegation to support these actions. Includes chip transfers for accepted offers/amendments and appropriate status updates in Firestore for all actions.